### PR TITLE
Fix message, add steamid

### DIFF
--- a/scripting/AntiDLL.sp
+++ b/scripting/AntiDLL.sp
@@ -131,7 +131,7 @@ void PlayerAction(int client)
 			}
 		}
 		
-		FormatEx(message, sizeof(message), "%T %N %T", "PREFIX", client, client, "REASON", client);
+		FormatEx(message, sizeof(message), "%T %L %T", "PREFIX", client, "REASON");
 		
 		if (iNotification & 8)
 		{


### PR DESCRIPTION
This fixes the message and removes unused client variables, also adds Steam ID. To me it makes sense and is most useful to at minimum log Steam ID, along with name.